### PR TITLE
Feat: Make menu position movable for user customization

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,4 +2,4 @@
 
 cd nepali-calendar-gs-extension@subashghimire.info.np
 
-zip -r ../nepali-calendar-gs-extension@subashghimire.info.np.zip *.js metadata.json stylesheet.css data/*.json utils/*.js
+zip -r ../nepali-calendar-gs-extension@subashghimire.info.np.zip *.js metadata.json stylesheet.css data/*.json utils/*.js schemas/*.xml

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+glib-compile-schemas ./nepali-calendar-gs-extension@subashghimire.info.np/schemas
+
 if (( $EUID == 0 )); then
 	INSTALL_DIR="/usr/share/gnome-shell/extensions"
 else

--- a/nepali-calendar-gs-extension@subashghimire.info.np/extension.js
+++ b/nepali-calendar-gs-extension@subashghimire.info.np/extension.js
@@ -169,7 +169,7 @@ export default class NepaliCalendar extends Extension {
     this._settings = this.getSettings();
     const position = this._settings.get_string('menu-position');
 
-    this._extension = new Indicator(this.path, position);
+    this._extension = new Indicator(this.path);
     this._addToPanel(position);
 
     this._positionChangedId = this._settings.connect(
@@ -188,7 +188,6 @@ export default class NepaliCalendar extends Extension {
     }
 
     if (this._settings) {
-      this._settings.run_dispose();
       this._settings = null;
     }
 

--- a/nepali-calendar-gs-extension@subashghimire.info.np/metadata.json
+++ b/nepali-calendar-gs-extension@subashghimire.info.np/metadata.json
@@ -8,6 +8,6 @@
         "46",
         "47"
     ],
-    "version": "4",
-    "settings-schema": "org.gnome.shell.extensions.nepal.calendar.gschema"
+    "version": 6,
+    "settings-schema": "org.gnome.shell.extensions.nepal-calendar"
 }

--- a/nepali-calendar-gs-extension@subashghimire.info.np/metadata.json
+++ b/nepali-calendar-gs-extension@subashghimire.info.np/metadata.json
@@ -8,5 +8,6 @@
         "46",
         "47"
     ],
-    "version": 3
+    "version": "4",
+    "settings-schema": "org.gnome.shell.extensions.nepal.calendar.gschema"
 }

--- a/nepali-calendar-gs-extension@subashghimire.info.np/prefs.js
+++ b/nepali-calendar-gs-extension@subashghimire.info.np/prefs.js
@@ -8,7 +8,7 @@ import Adw from 'gi://Adw';
 
 export default class NepaliCalendarPreferences extends ExtensionPreferences {
   fillPreferencesWindow(window) {
-    this.settings = this.getSettings();
+    window._settings = this.getSettings();
     const page = new Adw.PreferencesPage({
       title: _('General'),
       icon_name: 'dialog-information-symbolic',
@@ -22,14 +22,16 @@ export default class NepaliCalendarPreferences extends ExtensionPreferences {
     page.add(group);
 
     const positionOptions = [
-      { id: 'left', label: 'Left' },
-      { id: 'center', label: 'Center' },
-      { id: 'right', label: 'Right' },
+      { id: 'left', label: _('Left') },
+      { id: 'center', label: _('Center') },
+      { id: 'right', label: _('Right') },
     ];
 
     const positionComboRow = new Adw.ComboRow({
-      title: 'Date Position',
-      subtitle: 'Select where to place the Nepali Calendar menu on the panel',
+      title: _('Date Position'),
+      subtitle: _(
+        'Select where to place the Nepali Calendar menu on the panel'
+      ),
     });
 
     const stringList = new Gtk.StringList();
@@ -38,7 +40,7 @@ export default class NepaliCalendarPreferences extends ExtensionPreferences {
     positionComboRow.set_model(stringList);
 
     // Set the initial selected item based on the current setting
-    const currentPosition = this.settings.get_string('menu-position');
+    const currentPosition = window._settings.get_string('menu-position');
     const activeIndex = positionOptions.findIndex(
       (option) => option.id === currentPosition
     );
@@ -47,16 +49,15 @@ export default class NepaliCalendarPreferences extends ExtensionPreferences {
     // Update the setting when the selection changes
     positionComboRow.connect('notify::selected', (combo) => {
       const selectedOption = positionOptions[combo.selected];
-      this.settings.set_string('menu-position', selectedOption.id);
+      window._settings.set_string('menu-position', selectedOption.id);
     });
 
     group.add(positionComboRow);
 
-    window._settings = this.settings;
     window._settings.bind(
       'menu-position',
       positionComboRow,
-      'active',
+      'selected',
       Gio.SettingsBindFlags.DEFAULT
     );
   }

--- a/nepali-calendar-gs-extension@subashghimire.info.np/prefs.js
+++ b/nepali-calendar-gs-extension@subashghimire.info.np/prefs.js
@@ -1,0 +1,63 @@
+import {
+  ExtensionPreferences,
+  gettext as _,
+} from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
+import Gio from 'gi://Gio';
+import Gtk from 'gi://Gtk';
+import Adw from 'gi://Adw';
+
+export default class NepaliCalendarPreferences extends ExtensionPreferences {
+  fillPreferencesWindow(window) {
+    this.settings = this.getSettings();
+    const page = new Adw.PreferencesPage({
+      title: _('General'),
+      icon_name: 'dialog-information-symbolic',
+    });
+    window.add(page);
+
+    const group = new Adw.PreferencesGroup({
+      title: _('Appearance'),
+      description: _('Configure the appearance of the extension'),
+    });
+    page.add(group);
+
+    const positionOptions = [
+      { id: 'left', label: 'Left' },
+      { id: 'center', label: 'Center' },
+      { id: 'right', label: 'Right' },
+    ];
+
+    const positionComboRow = new Adw.ComboRow({
+      title: 'Date Position',
+      subtitle: 'Select where to place the Nepali Calendar menu on the panel',
+    });
+
+    const stringList = new Gtk.StringList();
+    positionOptions.forEach((option) => stringList.append(option.label));
+
+    positionComboRow.set_model(stringList);
+
+    // Set the initial selected item based on the current setting
+    const currentPosition = this.settings.get_string('menu-position');
+    const activeIndex = positionOptions.findIndex(
+      (option) => option.id === currentPosition
+    );
+    positionComboRow.set_selected(activeIndex !== -1 ? activeIndex : 0);
+
+    // Update the setting when the selection changes
+    positionComboRow.connect('notify::selected', (combo) => {
+      const selectedOption = positionOptions[combo.selected];
+      this.settings.set_string('menu-position', selectedOption.id);
+    });
+
+    group.add(positionComboRow);
+
+    window._settings = this.settings;
+    window._settings.bind(
+      'menu-position',
+      positionComboRow,
+      'active',
+      Gio.SettingsBindFlags.DEFAULT
+    );
+  }
+}

--- a/nepali-calendar-gs-extension@subashghimire.info.np/schemas/org.gnome.shell.extensions.nepal-calendar.gschema.xml
+++ b/nepali-calendar-gs-extension@subashghimire.info.np/schemas/org.gnome.shell.extensions.nepal-calendar.gschema.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schemalist>
-  <schema id="org.gnome.shell.extensions.nepal.calendar.gschema" path="/org/gnome/shell/extensions/nepali-calendar-gs-extension/">
+  <schema id="org.gnome.shell.extensions.nepal-calendar" path="/org/gnome/shell/extensions/nepal-calendar/">
     <key name="menu-position" type="s">
     <default>'center'</default>
         <summary>Position of the Nepali Calendar Menu</summary>

--- a/nepali-calendar-gs-extension@subashghimire.info.np/schemas/org.gnome.shell.extensions.nepal.calendar.gschema.xml
+++ b/nepali-calendar-gs-extension@subashghimire.info.np/schemas/org.gnome.shell.extensions.nepal.calendar.gschema.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schemalist>
+  <schema id="org.gnome.shell.extensions.nepal.calendar.gschema" path="/org/gnome/shell/extensions/nepali-calendar-gs-extension/">
+    <key name="menu-position" type="s">
+    <default>'center'</default>
+        <summary>Position of the Nepali Calendar Menu</summary>
+      <description>Allows users to choose where the menu is placed on the panel (e.g., 'left', 'center', 'right').</description>
+    </key>
+  </schema>
+</schemalist>


### PR DESCRIPTION
- Modify the extension.js file to add support for extension settings and menu position.
- Create a new prefs.js file to handle extension preferences.
- Add a new metadata.json file to specify the updated version and settings schema.
- Include a new gschema.xml file to define the extension's settings schema.
- Update the installation script to include the command for compiling schemas.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced user preferences for the Nepali Calendar extension, allowing customization of the menu position on the GNOME panel (Left, Center, Right).
  - Added a new settings schema for managing extension preferences.

- **Enhancements**
  - Improved dynamic management of the extension's position within the GNOME panel based on user settings.
  - Added a command to compile GSettings schemas during installation.

- **Version Update**
  - Updated the extension version to 4, reflecting the latest changes and enhancements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->