### PR TITLE
style(ui): increase Nepali calendar circle size and adjust margins

### DIFF
--- a/nepali-calendar-gs-extension@subashghimire.info.np/stylesheet.css
+++ b/nepali-calendar-gs-extension@subashghimire.info.np/stylesheet.css
@@ -23,11 +23,11 @@
     background-color: #ffffff;
     /* Neutral color for the circle */
     color: #000000b6;
-    border-radius: 50px;
+    border-radius: 60px;
     padding: 15px;
-    width: 50px;
-    height: 50px;
-    margin: 10px;
+    width: 60px;
+    height: 60px;
+    margin: 5px;
     align-items: center;
     justify-content: center;
 }


### PR DESCRIPTION
Fixes the truncation of Nepali day of week by increasing size of circle inside the popup from 50px to 60px. It also adjusts the margins from 10px to 5px.

Old:
![image](https://github.com/user-attachments/assets/a4839adc-42a1-44b6-a25c-92c106557f03)

New:
![image](https://github.com/user-attachments/assets/022cd09d-f63c-4619-90ad-69c6cc2b6056)

Related to #7
